### PR TITLE
fix: Unable to control BB-V2-0 thermostats

### DIFF
--- a/src/api/MysaApiClient.ts
+++ b/src/api/MysaApiClient.ts
@@ -374,7 +374,7 @@ export class MysaApiClient {
     this._logger.debug(`Sending request to set device state for '${deviceId}'...`);
     const payload = serializeMqttPayload<ChangeDeviceState>({
       msg: InMessageType.CHANGE_DEVICE_STATE,
-      id: now.unix(),
+      id: now.valueOf(),
       time: now.unix(),
       ver: '1.0',
       src: {


### PR DESCRIPTION
This change was identified while investigating why my BB-V2-0 Mysa would not respond to device state commands from Home Assistant (using mysq2mqtt).  The id type was previously in unix time (seconds), but should be in milliseconds per the reference here: https://github.com/dlenski/mysotherm/blob/main/mysa_messages.md  Making this update corrected the behavior and commands now work successfully.