### PR TITLE
fix: Support device model 'v1'

### DIFF
--- a/src/api/MysaApiClient.ts
+++ b/src/api/MysaApiClient.ts
@@ -423,15 +423,16 @@ export class MysaApiClient {
       resp: 2,
       body: {
         ver: 1,
-        type: device.Model.startsWith('BB-V1')
-          ? 1
-          : device.Model.startsWith('AC-V1')
-            ? 2
-            : device.Model.startsWith('BB-V2')
-              ? device.Model.endsWith('-L')
-                ? 5
-                : 4
-              : 0,
+        type:
+          device.Model.startsWith('BB-V1') || device.Model.startsWith('v1')
+            ? 1
+            : device.Model.startsWith('AC-V1')
+              ? 2
+              : device.Model.startsWith('BB-V2')
+                ? device.Model.endsWith('-L')
+                  ? 5
+                  : 4
+                : 0,
         cmd: [
           {
             tm: -1,


### PR DESCRIPTION
**Issue**
Some of my Mysa V1 return 'v1' instead of 'BB-V1-1' as their model (It seems to be the only difference, they work exactly like other V1). I was getting updates but was not able to send any changes.

**Fix**
Adding a check for 'v1' to the existing condition fixed my issue.