### PR TITLE
feat: parse AC device status messages (msg type 30) (fixes #214)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "scripts": {
     "example": "tsx --watch ./example/main.ts",
     "example:raw": "MYSA_OUTPUT_RAW_DATA=true tsx --watch ./example/main.ts",
-    "prepare": "tsup",
     "lint": "eslint --max-warnings 0 src/**/*.ts",
     "style-lint": "prettier -c .",
     "build": "tsup",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "scripts": {
     "example": "tsx --watch ./example/main.ts",
     "example:raw": "MYSA_OUTPUT_RAW_DATA=true tsx --watch ./example/main.ts",
+    "prepare": "tsup",
     "lint": "eslint --max-warnings 0 src/**/*.ts",
     "style-lint": "prettier -c .",
     "build": "tsup",

--- a/src/api/MysaApiClient.ts
+++ b/src/api/MysaApiClient.ts
@@ -897,6 +897,7 @@ export class MysaApiClient {
         }
       } else if (isMsgOutPayload(parsedPayload)) {
         switch (parsedPayload.msg) {
+          case OutMessageType.DEVICE_AC_STATUS:
           case OutMessageType.DEVICE_V2_STATUS:
             this.emitter.emit('statusChanged', {
               deviceId: parsedPayload.src.ref,

--- a/src/types/mqtt/MsgOutPayload.ts
+++ b/src/types/mqtt/MsgOutPayload.ts
@@ -1,3 +1,4 @@
+import { DeviceAcStatus } from './out/DeviceAcStatus';
 import { DeviceStateChange } from './out/DeviceStateChange';
 import { DeviceV2Status } from './out/DeviceV2Status';
 
@@ -7,4 +8,4 @@ import { DeviceV2Status } from './out/DeviceV2Status';
  * This type encompasses payloads where the message type is specified in the `msg` field rather than the `MsgType`
  * field. Includes device status reports and state change notifications.
  */
-export type MsgOutPayload = DeviceV2Status | DeviceStateChange;
+export type MsgOutPayload = DeviceAcStatus | DeviceV2Status | DeviceStateChange;

--- a/src/types/mqtt/out/DeviceAcStatus.ts
+++ b/src/types/mqtt/out/DeviceAcStatus.ts
@@ -4,8 +4,8 @@ import { OutMessageType } from './OutMessageType';
 /**
  * Interface representing a status report from a Mysa AC device.
  *
- * AC-V1-0 devices send this message (type 30) with environmental readings and AC-specific operational parameters.
- * This is the AC equivalent of {@link DeviceV2Status} (type 40) used by baseboard devices.
+ * AC-V1-0 devices send this message (type 30) with environmental readings and AC-specific operational parameters. This
+ * is the AC equivalent of {@link DeviceV2Status} (type 40) used by baseboard devices.
  */
 export interface DeviceAcStatus extends MsgPayload<OutMessageType.DEVICE_AC_STATUS> {
   /** Source information identifying the device sending the status */

--- a/src/types/mqtt/out/DeviceAcStatus.ts
+++ b/src/types/mqtt/out/DeviceAcStatus.ts
@@ -1,0 +1,31 @@
+import { MsgPayload } from '../MsgBasePayload';
+import { OutMessageType } from './OutMessageType';
+
+/**
+ * Interface representing a status report from a Mysa AC device.
+ *
+ * AC-V1-0 devices send this message (type 30) with environmental readings and AC-specific operational parameters.
+ * This is the AC equivalent of {@link DeviceV2Status} (type 40) used by baseboard devices.
+ */
+export interface DeviceAcStatus extends MsgPayload<OutMessageType.DEVICE_AC_STATUS> {
+  /** Source information identifying the device sending the status */
+  src: {
+    /** Reference identifier for the device */
+    ref: string;
+    /** Type identifier for the source device */
+    type: number;
+  };
+  /** Status data payload containing current device measurements and settings */
+  body: {
+    /** Ambient temperature reading from the device sensor (°C) */
+    ambTemp: number;
+    /** Relative humidity percentage */
+    hum: number;
+    /** Current temperature setpoint (°C) */
+    stpt: number;
+    /** Not present on AC devices (included for compatibility with DEVICE_V2_STATUS handler) */
+    dtyCycle?: number;
+    /** Operating mode (1=off, 2=auto, 3=heat, 4=cool, 5=fan_only, 6=dry) */
+    mode?: number;
+  };
+}

--- a/src/types/mqtt/out/OutMessageType.ts
+++ b/src/types/mqtt/out/OutMessageType.ts
@@ -28,6 +28,9 @@ export enum OutMessageType {
   /** Version 2 device status report with enhanced device information */
   DEVICE_V2_STATUS = 40,
 
+  /** AC device status report with temperature, humidity, setpoint, and AC-specific fields */
+  DEVICE_AC_STATUS = 30,
+
   /** Notification that a device's operational state has changed */
   DEVICE_STATE_CHANGE = 44
 }

--- a/src/types/mqtt/out/index.ts
+++ b/src/types/mqtt/out/index.ts
@@ -1,3 +1,4 @@
+export * from './DeviceAcStatus';
 export * from './DeviceLog';
 export * from './DevicePostBoot';
 export * from './DeviceSetpointChange';


### PR DESCRIPTION
## Problem

AC-V1-0 devices send temperature, humidity, and setpoint data via MQTT message type 30, but `_processMqttMessage` only handles msg types 40 (`DEVICE_V2_STATUS`) and 44 (`DEVICE_STATE_CHANGE`). This means `statusChanged` events never fire for AC devices — only `stateChanged` works.

## Root cause

The AC device pushes msg type 30 every ~5–30 seconds with the same `ambTemp`/`hum`/`stpt` fields as msg type 40, but since there's no `case 30` in the switch statement, these messages are silently dropped.

## Fix

Add `DEVICE_AC_STATUS = 30` to the `OutMessageType` enum and fall through to the existing `DEVICE_V2_STATUS` handler, since the body fields are identical.

Changes:
- Add `DEVICE_AC_STATUS = 30` to `OutMessageType` enum
- Add `DeviceAcStatus` interface (extends `MsgPayload`)
- Add `DeviceAcStatus` to `MsgOutPayload` union type
- Add fall-through case in `_processMqttMessage` parser
- Export `DeviceAcStatus` from barrel

## Raw MQTT evidence

Msg type 30 from an AC-V1-0 device (device ID anonymized):

```json
{
  "ver": "1.0",
  "src": { "type": 1, "ref": "aabbccddeeff" },
  "time": 1773850168,
  "msg": 30,
  "body": {
    "ambTemp": 22.6,
    "hum": 33,
    "stpt": 23.5,
    "mode": 3,
    "it": 1,
    "of": 3,
    "dir": 2,
    "stdy": 0,
    "drft": 2,
    "1": 2, "2": 3, "3": 26, "4": 3, "5": 6, "9": 2, "98": 3
  }
}
```

The `ambTemp`, `hum`, and `stpt` fields match the `DEVICE_V2_STATUS` (msg 40) schema exactly. The additional fields (`mode`, `dir`, `stdy`, `drft`, `of`, `it`, and numeric keys) are AC-specific and are not parsed by this patch — they're available via the existing `rawRealtimeMessageReceived` event for anyone who needs them.

There is also a msg type 31 (compact numeric-key variant) that fires alongside msg 30:

```json
{
  "ver": "1.0",
  "src": { "type": 1, "ref": "aabbccddeeff" },
  "time": 1773849930,
  "msg": 31,
  "body": { "1": 2, "2": 3, "3": 23.5, "4": 3, "5": 6, "9": 2, "98": 3 }
}
```

Partial decode: key `"2"` tracks mode, key `"3"` tracks setpoint. Not addressed in this patch.