### PR TITLE
fix(mqtt): release listeners on discarded connection before reconnect

### DIFF
--- a/src/api/MysaApiClient.ts
+++ b/src/api/MysaApiClient.ts
@@ -798,6 +798,15 @@ export class MysaApiClient {
         this._mqttConnectionPromise = undefined;
 
         try {
+          // Strip listeners before disconnect. Without this, the 6 event-
+          // handler closures registered above (`connect`,
+          // `connection_success`, `connection_failure`, `interrupt`,
+          // `resume`, `error`, `closed`) remain attached to the discarded
+          // connection object. Each closure captures `this` and `_logger`,
+          // and aws-crt's native binding retains the JS object via its
+          // internal callback refs — the dead connection never gets GC'd.
+          // After enough interrupt-storms the process heap grows until OOM.
+          connection.removeAllListeners();
           await connection.disconnect();
 
           try {


### PR DESCRIPTION
## Summary

The interrupt handler in `MysaApiClient._createMqttConnection` tears down the old MQTT connection on clientId-collision/credentials-expired storms (the `removeAllListeners`-less reset path starting at `MysaApiClient.ts:800`) and creates a new one, but it never removes the 6 event-listener closures registered on the discarded connection: `connect`, `connection_success`, `connection_failure`, `interrupt`, `resume`, `error`, `closed`.

Each closure captures `this` and `_logger`. aws-crt's native binding retains the JS connection object via its internal callback refs, so the dead connection is never GC'd — the closures keep the whole connection graph alive.

## Reproduction

Run the SDK against a Mysa cloud account that experiences frequent transient AWS IoT interrupts (e.g. a homelab on Cox/Verizon residential where TCP gets RST'd every few minutes), with `pino` or a wrapping logger that doesn't drop the log entries.

Observed behavior in production:
- Heap RSS grew from ~60 MiB to ~512 MiB over ~1 hour
- Each "High interrupt rate (N/60s). Possible clientId collision. Regenerating clientId..." log line corresponded to a step-up in retained memory
- Container OOMKilled ~11 times in 12 hours with a 512 MiB memory cgroup limit
- After bumping to 1 GiB, OOMs every ~2h instead

## Fix

Add `connection.removeAllListeners()` immediately before `connection.disconnect()` in the reset path so the closures become eligible for GC once aws-crt releases its internal references.

Verified on `mysa-js-sdk@2.0.3` built locally — the dead connection is now collected on the next major GC cycle and steady-state heap stays flat across reconnect storms.

## Out of scope (noted for follow-up)

The `resume` handler at `MysaApiClient.ts:827` also re-subscribes to every device topic on the *same* connection when `!sessionPresent`. If `resume` fires repeatedly with `!sessionPresent` (rare on AWS IoT but possible after broker session-expiry events) the per-device subscription callbacks may stack on aws-crt's subscription table — leaking additively until the connection itself is closed. Not fixing it here to keep this PR focused, but happy to follow up if you'd like.

## Test plan

- [x] Built locally with `npm run build`; verified the patched line is in `dist/index.js`
- [x] Deployed the patched SDK to my homelab Mysa-to-MQTT bridge; pod has been stable since (will report back after a 24h soak)
- [ ] No tests modified — this codepath isn't covered by the existing test suite