### PR TITLE
fix: sign every websocket handshake with freshly refreshed credentials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2547,7 +2547,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -4065,7 +4064,6 @@
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -4274,7 +4272,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4465,7 +4462,6 @@
       "integrity": "sha512-LPVCX4If8nAy1OERzmFx/pVr4g6olBqbz30SoLTkVJu5m5WH5GkhbIKnucQ1e5ZbpfNh+nrsFM2dolXO8ow4PQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/util-utf8-browser": "^3.259.0",
         "@httptoolkit/websocket-stream": "^6.0.1",
@@ -5889,7 +5885,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5953,7 +5948,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7576,7 +7570,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -10803,7 +10796,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11651,7 +11643,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12154,7 +12145,6 @@
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -13116,7 +13106,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13278,7 +13267,6 @@
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -13408,7 +13396,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13776,7 +13763,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
       "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -13824,7 +13810,6 @@
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/api/MysaApiClient.ts
+++ b/src/api/MysaApiClient.ts
@@ -18,7 +18,7 @@ import {
   CognitoUserPool,
   CognitoUserSession
 } from 'amazon-cognito-identity-js';
-import { iot, mqtt } from 'aws-iot-device-sdk-v2';
+import { auth, iot, mqtt } from 'aws-iot-device-sdk-v2';
 import { hash } from 'crypto';
 import dayjs, { Dayjs } from 'dayjs';
 import duration from 'dayjs/plugin/duration.js';
@@ -747,6 +747,53 @@ export class MysaApiClient {
       .with_reconnect_max_sec(30);
 
     const config = builder.build();
+
+    // `with_credentials` bakes the credentials fetched above into a static
+    // signer. Cognito credentials expire after ~1 hour; if the connection
+    // drops and the native reconnect loop is still retrying when they lapse,
+    // every subsequent handshake fails with a stale signature and no JS event
+    // is ever emitted (`interrupt` only fires when an *established* connection
+    // drops) — the client wedges silently, forever. Override the handshake
+    // transform so every (re)connect attempt signs with freshly refreshed
+    // credentials instead.
+    config.websocket_handshake_transform = async (request, done) => {
+      try {
+        const freshSession = await this._getFreshSession();
+        const freshCredentialsProvider = fromCognitoIdentityPool({
+          clientConfig: {
+            region: AwsRegion
+          },
+          identityPoolId: CognitoIdentityPoolId,
+          logins: {
+            [CognitoLoginKey]: freshSession.getIdToken().getJwtToken()
+          },
+          logger: this._logger
+        });
+        const freshCredentials = await freshCredentialsProvider();
+        if (freshCredentials.expiration) {
+          this._mqttCredentialsExpiration = dayjs(freshCredentials.expiration);
+        }
+
+        await auth.aws_sign_request(request, {
+          algorithm: auth.AwsSigningAlgorithm.SigV4,
+          signature_type: auth.AwsSignatureType.HttpRequestViaQueryParams,
+          provider: auth.AwsCredentialsProvider.newStatic(
+            freshCredentials.accessKeyId,
+            freshCredentials.secretAccessKey,
+            freshCredentials.sessionToken
+          ),
+          region: AwsRegion,
+          service: 'iotdevicegateway',
+          signed_body_value: auth.AwsSignedBodyValue.EmptySha256,
+          omit_session_token: true
+        });
+        done();
+      } catch (error) {
+        this._logger.error('Failed to sign MQTT websocket handshake with fresh credentials', error);
+        done(3 /* AWS_ERROR_UNKNOWN: fail this attempt; the reconnect loop retries */);
+      }
+    };
+
     const client = new mqtt.MqttClient();
     const connection = client.new_connection(config);
 


### PR DESCRIPTION
## Problem

#194 made the interrupt handler reset the connection when credentials are already expired at the moment an interrupt fires. There's a remaining hole: the websocket handshake is signed by `with_credentials()`, which bakes the Cognito credentials into a **static** signer (`AwsCredentialsProvider.newStatic` under the hood). Those credentials expire after ~1 hour.

If the connection drops while the credentials are still valid (so the interrupt handler takes no action) and the native reconnect loop is still retrying when they lapse, every subsequent handshake attempt fails with a stale signature. Failed reconnect *attempts* emit no JS event — `interrupt` only fires when an *established* connection drops — so from JavaScript's point of view nothing is happening: no events, no logs, no error. The client stays wedged until the process is restarted.

Observed in production (mysa2mqtt on k8s): the connection dropped, the process logged two `AWS_ERROR_MQTT_TIMEOUT` interrupts, then went completely silent for **9 days** while the pod looked healthy — devices stopped reporting because keep-alive publishes were queued on a connection that could never come back.

## Fix

After building the connection config, override `websocket_handshake_transform` with a transform that, on **every** (re)connect attempt:

1. refreshes the Cognito session via the existing `_getFreshSession()` (refresh-token aware),
2. fetches fresh identity-pool credentials,
3. signs the handshake with those credentials (same SigV4 query-param signing the builder's default transform uses),
4. keeps `_mqttCredentialsExpiration` current so the interrupt-handler heuristic from #194 stays accurate.

A signing failure calls `done(error_code)`, which fails that attempt and lets the native reconnect loop retry with backoff — so transient Cognito outages are also survived instead of aborting.

The initial credentials fetch in `_createMqttConnection` is kept: it still provides fail-fast behavior and the expiration bookkeeping on first connect.

## Testing

- `npm run build` and `npm run lint` pass.
- Running in production since 2026-07-17: connection re-established, devices reporting, reconnects across the hourly credential expiry now succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
